### PR TITLE
Alien::Base 0.020

### DIFF
--- a/lib/Dist/Zilla/Plugin/Alien.pm
+++ b/lib/Dist/Zilla/Plugin/Alien.pm
@@ -156,6 +156,14 @@ in L<Alien::Base::ModuleBuild> during the build/install step) using the equal C<
  [Alien]
  helper = mytool = 'mytool --foo --bar'
 
+=head2 provides_cflags
+
+Sets the C<alien_provides_cflags> property for L<Alien::Base::ModuleBuild>.
+
+=head2 provides_libs
+
+Sets the C<alien_provides_libs> property for L<Alien::Base::ModuleBuild>.
+
 =head1 InstallRelease
 
 The method L<Alien::Base> is using would compile the complete Alien 2 times, if
@@ -314,6 +322,16 @@ has stage_install => (
 	is  => 'rw',
 );
 
+has provides_cflags => (
+	isa => 'Str',
+	is  => 'rw',
+);
+
+has provides_libs => (
+	isa => 'Str',
+	is  => 'rw',
+);
+
 # multiple build/install commands return as an arrayref
 around mvp_multivalue_args => sub {
   my ($orig, $self) = @_;
@@ -443,6 +461,8 @@ around module_build_args => sub {
 		defined $self->isolate_dynamic ? (alien_isolate_dynamic => $self->isolate_dynamic) : (),
 		defined $self->msys ? (alien_msys => $self->msys) : (),
 		defined $self->stage_install ? (alien_stage_install => $self->stage_install) : (),
+		defined $self->provides_libs ? (alien_provides_libs => $self->provides_libs) : (),
+		defined $self->provides_cflags ? (alien_provides_cflags => $self->provides_cflags) : (),
 		%$bin_requires ? ( alien_bin_requires => $bin_requires ) : (),
 		%$helper ? ( alien_helper => $helper ): (),
 	};

--- a/lib/Dist/Zilla/Plugin/Alien.pm
+++ b/lib/Dist/Zilla/Plugin/Alien.pm
@@ -68,6 +68,10 @@ alienfied product. It is set together out of I<pattern_prefix>,
 I<pattern_version> and I<pattern_suffix>. I<pattern_prefix> is by default
 L</name> together with a dash.
 
+=head2 exact_filename
+
+Instead of providing a pattern you may use this to set the exact filename.
+
 =head2 bins
 
 A space or tab seperated list of all binaries that should be wrapped to be executable
@@ -262,6 +266,11 @@ sub _build_pattern {
 	);
 }
 
+has exact_filename => (
+	isa => 'Str',
+	is  => 'rw',
+);
+
 has build_command => (
 	isa => 'ArrayRef[Str]',
 	is => 'rw',
@@ -429,6 +438,7 @@ __EOT__
 around module_build_args => sub {
 	my ($orig, $self, @args) = @_;
 	my $pattern = $self->pattern;
+	my $exact_filename = $self->exact_filename;
 
 	my $bin_requires = $self->_bin_requires_hash;
 	my $helper       = $self->_helper_hash;
@@ -452,7 +462,7 @@ around module_build_args => sub {
 			# modifier, but then getting serialised as
 			# (?^u:$pattern) which fails to parse under perl less
 			# than v5.014.
-			pattern => "^$pattern\$",
+			defined $exact_filename ? (exact_filename => $exact_filename) : (pattern => "^$pattern\$"),
 		},
 		(alien_build_commands => $self->build_command)x!! $self->build_command,
 		(alien_install_commands => $self->install_command)x!! $self->install_command,


### PR DESCRIPTION
This adds in `0.020` features as well as some older AB features which I guess never made it into the plugin.

I'm happy to wait to merge this for when `0.020` goes to CPAN, or if you want to do it now that is okay too.  Just wanted to have it queued up and ready to go.

Tested this with this change:

https://github.com/plicease/Alien-Libbz2/commit/8b0504836caf88872738b1b7ccd568969c8a42c8

My goal for this is to make `Alien::Libbz2` a good (as in simple and easy to understand) example for 

 * non-autoconf
 * non-pkg-config
 * dzil based

as it will be referenced from the FAQ.

fyi @jberger @mohawk2