### PR TITLE
Make configure_requires Alien::Base::ModuleBuild

### DIFF
--- a/lib/Dist/Zilla/Plugin/Alien.pm
+++ b/lib/Dist/Zilla/Plugin/Alien.pm
@@ -385,7 +385,7 @@ sub register_prereqs {
 			type  => 'requires',
 			phase => 'configure',
 		},
-		'Alien::Base' => $ab_version,
+		'Alien::Base::ModuleBuild' => $ab_version,
 		'File::ShareDir' => '1.03',
 		@{ $self->split_bins } > 0 ? ('Path::Class' => '0.013') : (),
 		%$configure_requires,

--- a/t/bin_requires.t
+++ b/t/bin_requires.t
@@ -26,7 +26,8 @@ subtest 'bin_requires' => sub {
 
   is $plugin->module_build_args->{alien_bin_requires}->{"Alien::foo"}, 0, "Alien::foo = 0";
   is $plugin->module_build_args->{alien_bin_requires}->{"Alien::bar"}, '2.0', "Alien::bar = 2.0";
-  is $tzil->prereqs->as_string_hash->{configure}->{requires}->{'Alien::Base'}, '0.006', 'configure prereq';
+  is $tzil->prereqs->as_string_hash->{runtime}->{requires}->{'Alien::Base'}, '0.006', 'configure prereq';
+  is $tzil->prereqs->as_string_hash->{configure}->{requires}->{'Alien::Base::ModuleBuild'}, '0.006', 'configure prereq';
   is $tzil->prereqs->as_string_hash->{configure}->{requires}->{'Alien::foo'}, '0', 'configure prereq';
   is $tzil->prereqs->as_string_hash->{configure}->{requires}->{'Alien::bar'}, '2.0', 'configure prereq';
 };

--- a/t/inline_auto_include.t
+++ b/t/inline_auto_include.t
@@ -25,7 +25,8 @@ subtest 'plugin' => sub {
   my($plugin) = grep { $_->isa('Dist::Zilla::Plugin::Alien') } @{ $tzil->plugins };
   is_deeply $plugin->module_build_args->{alien_inline_auto_include}, [qw( foo.h bar.h baz.h )], 'includes = foo.h bar.h baz.h';
 
-  is $tzil->prereqs->as_string_hash->{configure}->{requires}->{'Alien::Base'}, '0.006', 'configure prereq';
+  is $tzil->prereqs->as_string_hash->{runtime}->{requires}->{'Alien::Base'}, '0.006', 'configure prereq';
+  is $tzil->prereqs->as_string_hash->{configure}->{requires}->{'Alien::Base::ModuleBuild'}, '0.006', 'configure prereq';
   is $tzil->prereqs->as_string_hash->{runtime}->{requires}->{'Alien::Base'}, '0.006', 'runtime prereq';
 
 };

--- a/t/msys.t
+++ b/t/msys.t
@@ -25,7 +25,8 @@ subtest 'msys on' => sub {
   my($plugin) = grep { $_->isa('Dist::Zilla::Plugin::Alien') } @{ $tzil->plugins };
 
   is $plugin->module_build_args->{alien_msys}, 1, "aien_msys = 1";
-  is $tzil->prereqs->as_string_hash->{configure}->{requires}->{'Alien::Base'}, '0.006', 'configure prereq';
+  is $tzil->prereqs->as_string_hash->{runtime}->{requires}->{'Alien::Base'}, '0.006', 'runtime prereq';
+  is $tzil->prereqs->as_string_hash->{configure}->{requires}->{'Alien::Base::ModuleBuild'}, '0.006', 'configure prereq';
 };
 
 subtest 'msys off' => sub {


### PR DESCRIPTION
Instead of requiring Alien::Base require the installer class that will actually be used during the configure stage.  This has a couple of advantages:

  - As mentioned, it is the actual module that will be used during
    the configure stage
  - If we ever implement an alternate installer (either based on
    EUMM or a MB replacement) then the first thing that we will
    want to do is separate AB::MB from the main AB dist.  This
    will help future proof this process, for at least dists using
    the plugin going forward.